### PR TITLE
Parameters may be null

### DIFF
--- a/Analyzer/Query.php
+++ b/Analyzer/Query.php
@@ -43,9 +43,14 @@ class Query
         return $this->filterIndistinctQueries($groupedQueries);
     }
 
-    private function generateQueryKeyWithParameters($sql, array $parameters)
+    private function generateQueryKeyWithParameters($sql, $parameters)
     {
-        return $this->generateQueryKeyWithoutParameters($sql) . ':' . sha1(serialize($parameters));
+        $key = $this->generateQueryKeyWithoutParameters($sql);
+        if (is_array($parameters)) {
+            $key .= ':' . sha1(serialize($parameters));
+        }
+        
+        return $key;
     }
 
     private function generateQueryKeyWithoutParameters($sql)


### PR DESCRIPTION
Fixed `generateQueryKeyWithParameters` because parameters may be null (and so, not an array).
