### PR TITLE
updated symfony dep to allow all 2.x versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": ">=2.1.0,<2.3-dev",
+        "symfony/symfony": "~2.1",
         "doctrine/doctrine-bundle": ">=1.0.0,<1.3-dev"
     },
     "autoload": {


### PR DESCRIPTION
It should be possible for this bundle to be compatible for all subsequent 2.x releases, so this change declares the dependencies as such.
